### PR TITLE
Add simple fallback scroll animation if a shader pack is used

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/client/ShaderMods.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/ShaderMods.java
@@ -1,0 +1,53 @@
+package com.direwolf20.justdirethings.client;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class ShaderMods {
+    private static boolean usingOptifine;
+    private static boolean usingIris;
+    private static MethodHandle shaderAccess;
+    private static Object instance;
+
+    static {
+        try {
+            Class<?> clazz = Class.forName("net.irisshaders.iris.api.v0.IrisApi");
+            shaderAccess = MethodHandles.lookup().findVirtual(clazz, "isShaderPackInUse", MethodType.methodType(boolean.class));
+            instance = MethodHandles.lookup().findStatic(clazz, "getInstance", MethodType.methodType(clazz)).invoke();
+            usingIris = true;
+        } catch (Throwable ignored) {
+
+        }
+
+        if (shaderAccess == null) {
+            // Try Optifine
+            try {
+                shaderAccess = MethodHandles.lookup().findStatic(Class.forName("net.optifine.Config"), "isShaders", MethodType.methodType(boolean.class));
+                usingOptifine = true;
+            } catch (NoSuchMethodException | IllegalAccessException | ClassNotFoundException ignored) {
+
+            }
+        }
+    }
+
+    public static boolean usingShaders() {
+        if (usingIris) {
+            try {
+                return (boolean) shaderAccess.invoke(instance);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (usingOptifine) {
+            try {
+                return (boolean) shaderAccess.invoke();
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This adds a fallback scrolling animation if a shader pack is being used.

Normal animation:

![2024-07-01_20 05 26](https://github.com/Direwolf20-MC/JustDireThings/assets/31803019/3afa8ba5-5c0c-4eaa-8089-a57e75a500c7)

Broken animation currently when shaders are in use:

![2024-07-01_20 06 50](https://github.com/Direwolf20-MC/JustDireThings/assets/31803019/35d126df-5a58-473c-b660-ce34601a8edd)

New fallback animation (rotates slightly):

![2024-07-01_20 05 30](https://github.com/Direwolf20-MC/JustDireThings/assets/31803019/4956007e-176b-40a7-94b0-a3acf05ec62d)
