### PR TITLE
Make time wand max multiplier configurable

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/client/entityrenders/TimeWandEntityRender.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/entityrenders/TimeWandEntityRender.java
@@ -2,6 +2,7 @@ package com.direwolf20.justdirethings.client.entityrenders;
 
 import com.direwolf20.justdirethings.client.renderers.RenderHelpers;
 import com.direwolf20.justdirethings.common.entities.TimeWandEntity;
+import com.direwolf20.justdirethings.setup.Config;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.ChatFormatting;
@@ -25,7 +26,7 @@ public class TimeWandEntityRender extends EntityRenderer<TimeWandEntity> {
         matrixStackIn.pushPose();
 
         // Calculate the progress for tick rate and time remaining
-        float tickRateProgress = pEntity.getTickSpeed() / 8.0f; // Assuming max rate is 8
+        float tickRateProgress = pEntity.getTickSpeed() / (float) Config.logBase2(Config.TIME_WAND_MAX_MULTIPLIER.get());
         float timeProgress = (float) pEntity.getRemainingTime() / pEntity.getTotalTime(); // Assuming methods for total time
 
         // Render progress bars on all 6 sides of the block

--- a/src/main/java/com/direwolf20/justdirethings/common/items/TimeWand.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/items/TimeWand.java
@@ -71,7 +71,7 @@ public class TimeWand extends BasePoweredItem implements PoweredItem, FluidConta
         if (existingEntity.isPresent()) {
             TimeWandEntity timeWandEntity = existingEntity.get();
             setRate = timeWandEntity.getTickSpeed() + 1;
-            if (setRate > 8) //Config?
+            if (setRate > Config.logBase2(Config.TIME_WAND_MAX_MULTIPLIER.get()))
                 return false;
             float accelRate = TimeWandEntity.calculateAccelRate(setRate);
             int cost = calculateFluidCost(player, (int) accelRate);

--- a/src/main/java/com/direwolf20/justdirethings/setup/Config.java
+++ b/src/main/java/com/direwolf20/justdirethings/setup/Config.java
@@ -1,14 +1,18 @@
 package com.direwolf20.justdirethings.setup;
 
 import com.direwolf20.justdirethings.common.items.interfaces.Ability;
+import com.mojang.logging.LogUtils;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
 
 public class Config {
+    public static final Logger LOGGER = LogUtils.getLogger();
+
     public static final ModConfigSpec.Builder CLIENT_BUILDER = new ModConfigSpec.Builder();
     public static final ModConfigSpec.Builder COMMON_BUILDER = new ModConfigSpec.Builder();
     public static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
@@ -55,7 +59,7 @@ public class Config {
     public static ModConfigSpec.IntValue TIME_WAND_RF_CAPACITY;
     public static ModConfigSpec.IntValue TIMEWAND_RF_COST;
     public static ModConfigSpec.DoubleValue TIMEWAND_FLUID_COST;
-    public static ModConfigSpec.IntValue TIME_WAND_MAX_MULTIPLIER;
+    public static ModConfigSpec.ConfigValue<Integer> TIME_WAND_MAX_MULTIPLIER;
 
     public static final String CATEGORY_PARADOX_MACHINE = "paradox_machine";
     public static ModConfigSpec.IntValue PARADOX_TOTAL_FLUID_CAPACITY;
@@ -226,9 +230,14 @@ public class Config {
                 .defineInRange("time_wand_rf_cost", 100, 0, Integer.MAX_VALUE);
         TIMEWAND_FLUID_COST = COMMON_BUILDER.comment("The Time Fluid cost to use the time wand.  This value is multiplied by the acceleration amount. For example, when you go from 128 to 256, it will charge 256 x <this value> in Time Fluid.")
                 .defineInRange("time_wand_fluid_cost", 0.5, 0, Double.MAX_VALUE);
-        // TODO: Add validation that this is a power of two. I'm not sure exactly how to do that without copying and modifying a bunch of code from ModConfigSpec.
         TIME_WAND_MAX_MULTIPLIER = COMMON_BUILDER.comment("The maximum speed multiplier that can be applied using a Time Wand. This value should be a power of two.")
-                .defineInRange("time_wand_max_multiplier", 256, 2, Integer.MAX_VALUE);
+                .define("time_wand_max_multiplier", 256, value -> {
+                    final boolean validPowerOfTwo = (int) Math.pow(2, logBase2((int) value)) == (int) value;
+                    if (!validPowerOfTwo || (int) value < 2) {
+                        LOGGER.error("Invalid time_wand_max_multiplier {}, must be power of 2 and >=2", value);
+                    }
+                    return validPowerOfTwo;
+                });
         COMMON_BUILDER.pop();
     }
 

--- a/src/main/java/com/direwolf20/justdirethings/setup/Config.java
+++ b/src/main/java/com/direwolf20/justdirethings/setup/Config.java
@@ -13,6 +13,8 @@ public class Config {
     public static final ModConfigSpec.Builder COMMON_BUILDER = new ModConfigSpec.Builder();
     public static final ModConfigSpec.Builder SERVER_BUILDER = new ModConfigSpec.Builder();
 
+    public static ModConfigSpec COMMON_CONFIG;
+
     public static final String OVERLAY_POSITION = "overlay_position";
     public static ModConfigSpec.IntValue OVERLAY_X;
     public static ModConfigSpec.IntValue OVERLAY_Y;
@@ -100,7 +102,8 @@ public class Config {
         portalGunConfig();
         timeWandConfig();
         paradoxConfig();
-        container.registerConfig(ModConfig.Type.COMMON, COMMON_BUILDER.build());
+        COMMON_CONFIG = COMMON_BUILDER.build();
+        container.registerConfig(ModConfig.Type.COMMON, COMMON_CONFIG);
     }
 
     private static void registerServerConfigs(ModContainer container) {

--- a/src/main/java/com/direwolf20/justdirethings/setup/Config.java
+++ b/src/main/java/com/direwolf20/justdirethings/setup/Config.java
@@ -53,6 +53,7 @@ public class Config {
     public static ModConfigSpec.IntValue TIME_WAND_RF_CAPACITY;
     public static ModConfigSpec.IntValue TIMEWAND_RF_COST;
     public static ModConfigSpec.DoubleValue TIMEWAND_FLUID_COST;
+    public static ModConfigSpec.IntValue TIME_WAND_MAX_MULTIPLIER;
 
     public static final String CATEGORY_PARADOX_MACHINE = "paradox_machine";
     public static ModConfigSpec.IntValue PARADOX_TOTAL_FLUID_CAPACITY;
@@ -222,7 +223,14 @@ public class Config {
                 .defineInRange("time_wand_rf_cost", 100, 0, Integer.MAX_VALUE);
         TIMEWAND_FLUID_COST = COMMON_BUILDER.comment("The Time Fluid cost to use the time wand.  This value is multiplied by the acceleration amount. For example, when you go from 128 to 256, it will charge 256 x <this value> in Time Fluid.")
                 .defineInRange("time_wand_fluid_cost", 0.5, 0, Double.MAX_VALUE);
+        // TODO: Add validation that this is a power of two. I'm not sure exactly how to do that without copying and modifying a bunch of code from ModConfigSpec.
+        TIME_WAND_MAX_MULTIPLIER = COMMON_BUILDER.comment("The maximum speed multiplier that can be applied using a Time Wand. This value should be a power of two.")
+                .defineInRange("time_wand_max_multiplier", 256, 2, Integer.MAX_VALUE);
         COMMON_BUILDER.pop();
+    }
+
+    public static int logBase2(final int value) {
+        return (int) (Math.log(value) / Math.log(2));
     }
 
     private static void paradoxConfig() {

--- a/src/main/java/com/direwolf20/justdirethings/util/ConfigValueComponentProcessor.java
+++ b/src/main/java/com/direwolf20/justdirethings/util/ConfigValueComponentProcessor.java
@@ -1,0 +1,36 @@
+package com.direwolf20.justdirethings.util;
+
+import com.direwolf20.justdirethings.setup.Config;
+import java.util.Set;
+import net.minecraft.world.level.Level;
+import net.neoforged.neoforge.common.ModConfigSpec;
+import vazkii.patchouli.api.IComponentProcessor;
+import vazkii.patchouli.api.IVariable;
+import vazkii.patchouli.api.IVariableProvider;
+
+public class ConfigValueComponentProcessor implements IComponentProcessor {
+    private String rawText;
+
+    @Override
+    public void setup(final Level level, final IVariableProvider iVariableProvider) {
+        this.rawText = iVariableProvider.get("text", level.registryAccess()).asString();
+    }
+
+    @Override
+    public IVariable process(final Level level, final String key) {
+        if (!key.equals("text")) {
+            return null;
+        }
+
+        final Set<ModConfigSpec.ConfigValue<?>> options = Set.of(Config.TIME_WAND_MAX_MULTIPLIER);
+
+        String result = this.rawText;
+
+        for (final ModConfigSpec.ConfigValue<?> option : options) {
+            final Object value = option.get();
+            result = result.replace("#" + String.join(".", option.getPath()) + "#", String.valueOf(value));
+        }
+
+        return IVariable.wrap(result, level.registryAccess());
+    }
+}

--- a/src/main/java/com/direwolf20/justdirethings/util/ConfigValueComponentProcessor.java
+++ b/src/main/java/com/direwolf20/justdirethings/util/ConfigValueComponentProcessor.java
@@ -1,7 +1,7 @@
 package com.direwolf20.justdirethings.util;
 
 import com.direwolf20.justdirethings.setup.Config;
-import java.util.Set;
+import java.util.List;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.common.ModConfigSpec;
 import vazkii.patchouli.api.IComponentProcessor;
@@ -10,10 +10,16 @@ import vazkii.patchouli.api.IVariableProvider;
 
 public class ConfigValueComponentProcessor implements IComponentProcessor {
     private String rawText;
+    private List<String> options;
 
     @Override
     public void setup(final Level level, final IVariableProvider iVariableProvider) {
         this.rawText = iVariableProvider.get("text", level.registryAccess()).asString();
+        this.options = iVariableProvider.get("config_options", level.registryAccess())
+            .asList(level.registryAccess())
+            .stream()
+            .map(IVariable::asString)
+            .toList();
     }
 
     @Override
@@ -22,13 +28,11 @@ public class ConfigValueComponentProcessor implements IComponentProcessor {
             return null;
         }
 
-        final Set<ModConfigSpec.ConfigValue<?>> options = Set.of(Config.TIME_WAND_MAX_MULTIPLIER);
-
         String result = this.rawText;
 
-        for (final ModConfigSpec.ConfigValue<?> option : options) {
-            final Object value = option.get();
-            result = result.replace("#" + String.join(".", option.getPath()) + "#", String.valueOf(value));
+        for (final String option : this.options) {
+            final Object value = ((ModConfigSpec.ConfigValue<?>) Config.COMMON_CONFIG.getValues().get(option)).get();
+            result = result.replace("#" + option + "#", String.valueOf(value));
         }
 
         return IVariable.wrap(result, level.registryAccess());

--- a/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/entries/item_time_wand.json
+++ b/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/entries/item_time_wand.json
@@ -9,8 +9,8 @@
       "text": "The Time Wand is a portable way to take advantage of the time altering abilities of $(l:justdirethings:res_time_crystal)Time Crystals$(/l)$(br2)Do note, to use this wand you'll need to charge it with both Forge Energy and $(l:justdirethings:res_time_fluid)Time Fluid$(/l)"
     },
     {
-      "type": "patchouli:text",
-      "text": "Simply right click on any block that ticks - this includes machines like Furnaces, and crops like Wheat. At first, it will cause the block to run twice as fast. Click again to double it to 4x, then 8x, all the way up to 256x speed!$(br2)Each acceleration will consume both Forge Energy and Time Fluid based on how fast the speed increase is.$(br2)This speed increase will last for 30 seconds."
+      "type": "justdirethings:text_with_config",
+      "text": "Simply right click on any block that ticks - this includes machines like Furnaces, and crops like Wheat. At first, it will cause the block to run twice as fast. Click again to double it to 4x, then 8x, all the way up to #time_wand.time_wand_max_multiplier#x speed!$(br2)Each acceleration will consume both Forge Energy and Time Fluid based on how fast the speed increase is.$(br2)This speed increase will last for 30 seconds."
     },
     {
       "type": "patchouli:crafting",

--- a/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/entries/item_time_wand.json
+++ b/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/entries/item_time_wand.json
@@ -10,7 +10,10 @@
     },
     {
       "type": "justdirethings:text_with_config",
-      "text": "Simply right click on any block that ticks - this includes machines like Furnaces, and crops like Wheat. At first, it will cause the block to run twice as fast. Click again to double it to 4x, then 8x, all the way up to #time_wand.time_wand_max_multiplier#x speed!$(br2)Each acceleration will consume both Forge Energy and Time Fluid based on how fast the speed increase is.$(br2)This speed increase will last for 30 seconds."
+      "text": "Simply right click on any block that ticks - this includes machines like Furnaces, and crops like Wheat. At first, it will cause the block to run twice as fast. Click again to double it to 4x, then 8x, all the way up to #time_wand.time_wand_max_multiplier#x speed!$(br2)Each acceleration will consume both Forge Energy and Time Fluid based on how fast the speed increase is.$(br2)This speed increase will last for 30 seconds.",
+      "config_options": [
+        "time_wand.time_wand_max_multiplier"
+      ]
     },
     {
       "type": "patchouli:crafting",

--- a/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/templates/text_with_config.json
+++ b/src/main/resources/assets/justdirethings/patchouli_books/justdirethingsbook/en_us/templates/text_with_config.json
@@ -1,0 +1,9 @@
+{
+  "processor": "com.direwolf20.justdirethings.util.ConfigValueComponentProcessor",
+  "components": [
+    {
+      "type": "patchouli:text",
+      "text": "#text"
+    }
+  ]
+}


### PR DESCRIPTION
Pack authors are currently abusing the power usage/storage configs to
impose a lower max multiplier. Adding a dedicated option lets
pack authors do this without making the book & renderer confusing.