### PR TITLE
Fix Smithing Category Extensions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,5 +43,6 @@ mod_authors=Direwolf20
 mod_description=Just some things that Direwolf20 wanted.
 #Dependencies
 jei_mc_version=1.21.1
-jei_version=19.15.0.149
+# jei 1.21.1 versions: https://maven.blamejared.com/mezz/jei/jei-1.21.1-neoforge/maven-metadata.xml
+jei_version=19.16.0.155
 patchouli_version=1.21-87-NEOFORGE-SNAPSHOT

--- a/src/main/java/com/direwolf20/justdirethings/client/jei/AbilityRecipeCategory.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/AbilityRecipeCategory.java
@@ -2,8 +2,15 @@ package com.direwolf20.justdirethings.client.jei;
 
 import com.direwolf20.justdirethings.datagen.recipes.AbilityRecipe;
 import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.category.extensions.vanilla.smithing.ISmithingCategoryExtension;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.SmithingRecipeInput;
 
 public class AbilityRecipeCategory implements ISmithingCategoryExtension<AbilityRecipe> {
 
@@ -26,5 +33,32 @@ public class AbilityRecipeCategory implements ISmithingCategoryExtension<Ability
     public <T extends IIngredientAcceptor<T>> void setTemplate(AbilityRecipe recipe, T ingredientAcceptor) {
         Ingredient ingredient = recipe.getTemplate();
         ingredientAcceptor.addIngredients(ingredient);
+    }
+
+    @Override
+    public <T extends IIngredientAcceptor<T>> void setOutput(AbilityRecipe recipe, T ingredientAcceptor) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        assert level != null;
+        RegistryAccess registryAccess = level.registryAccess();
+        ItemStack resultItem = recipe.getResultItem(registryAccess);
+        ingredientAcceptor.addItemStack(resultItem);
+    }
+
+    @Override
+    public void onDisplayedIngredientsUpdate(AbilityRecipe recipe, IRecipeSlotDrawable templateSlot, IRecipeSlotDrawable baseSlot, IRecipeSlotDrawable additionSlot, IRecipeSlotDrawable outputSlot, IFocusGroup focuses) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        assert level != null;
+        RegistryAccess registryAccess = level.registryAccess();
+
+        SmithingRecipeInput input = new SmithingRecipeInput(
+            templateSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY),
+            baseSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY),
+            additionSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY)
+        );
+        ItemStack result = recipe.assemble(input, registryAccess);
+        outputSlot.createDisplayOverrides()
+            .addItemStack(result);
     }
 }

--- a/src/main/java/com/direwolf20/justdirethings/client/jei/PaxelRecipeCategory.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/PaxelRecipeCategory.java
@@ -2,8 +2,15 @@ package com.direwolf20.justdirethings.client.jei;
 
 import com.direwolf20.justdirethings.datagen.recipes.PaxelRecipe;
 import mezz.jei.api.gui.builder.IIngredientAcceptor;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.category.extensions.vanilla.smithing.ISmithingCategoryExtension;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.SmithingRecipeInput;
 
 public class PaxelRecipeCategory implements ISmithingCategoryExtension<PaxelRecipe> {
 
@@ -26,5 +33,33 @@ public class PaxelRecipeCategory implements ISmithingCategoryExtension<PaxelReci
     public <T extends IIngredientAcceptor<T>> void setTemplate(PaxelRecipe recipe, T ingredientAcceptor) {
         Ingredient ingredient = recipe.getTemplate();
         ingredientAcceptor.addIngredients(ingredient);
+    }
+
+
+    @Override
+    public <T extends IIngredientAcceptor<T>> void setOutput(PaxelRecipe recipe, T ingredientAcceptor) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        assert level != null;
+        RegistryAccess registryAccess = level.registryAccess();
+        ItemStack resultItem = recipe.getResultItem(registryAccess);
+        ingredientAcceptor.addItemStack(resultItem);
+    }
+
+    @Override
+    public void onDisplayedIngredientsUpdate(PaxelRecipe recipe, IRecipeSlotDrawable templateSlot, IRecipeSlotDrawable baseSlot, IRecipeSlotDrawable additionSlot, IRecipeSlotDrawable outputSlot, IFocusGroup focuses) {
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        assert level != null;
+        RegistryAccess registryAccess = level.registryAccess();
+
+        SmithingRecipeInput input = new SmithingRecipeInput(
+            templateSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY),
+            baseSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY),
+            additionSlot.getDisplayedItemStack().orElse(ItemStack.EMPTY)
+        );
+        ItemStack result = recipe.assemble(input, registryAccess);
+        outputSlot.createDisplayOverrides()
+            .addItemStack(result);
     }
 }


### PR DESCRIPTION
Sorry, I had to make some breaking changes to how the smithing category extensions work in order to support more types of recipes.
It isn't crashing, but the recipe outputs aren't being shown in JEI on your smithing recipes right now.

Since the feature is very new (I think you're the only person using it) I am submitting a fix here!