### PR TITLE
Added cycle setting information to action bar

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/ToggleableTool.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/ToggleableTool.java
@@ -394,11 +394,20 @@ public interface ToggleableTool extends ToggleableItem {
         if (!level.isClientSide) {
             for (Ability ability : getAllPassiveAbilities()) {
                 if (customBindAbilities.contains(ability)) {
-                    if (ability.settingType == Ability.SettingType.CYCLE)
-                        ToggleableTool.cycleSetting(itemStack, ability.getName());
-                    else
+                    if (ability.settingType == Ability.SettingType.CYCLE) {
+                        String abilityName = ability.getName();
+                        ToggleableTool.cycleSetting(itemStack, abilityName);
+                        boolean is_enabled = ToggleableTool.getSetting(itemStack, abilityName);
+                        if (is_enabled) {
+                            int currentValue = getToolValue(itemStack, abilityName);
+                            player.displayClientMessage(Component.translatable("justdirethings.ability", Component.translatable(ability.getLocalization() + "_" + currentValue), Component.translatable("justdirethings.enabled")), true);
+                        } else {
+                            player.displayClientMessage(Component.translatable("justdirethings.ability", Component.translatable(ability.getLocalization()), Component.translatable("justdirethings.disabled")), true);
+                        }
+                    } else {
                         ToggleableTool.toggleSetting(itemStack, ability.getName());
-                    player.displayClientMessage(Component.translatable("justdirethings.ability", Component.translatable(ability.getLocalization()), ToggleableTool.getSetting(itemStack, ability.getName()) ? Component.translatable("justdirethings.enabled") : Component.translatable("justdirethings.disabled")), true);
+                        player.displayClientMessage(Component.translatable("justdirethings.ability", Component.translatable(ability.getLocalization()), ToggleableTool.getSetting(itemStack, ability.getName()) ? Component.translatable("justdirethings.enabled") : Component.translatable("justdirethings.disabled")), true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds #218.
When pressing a hotkey for a non-cycle ability, it functions exactly the same as before. But now when pressing the hotkey for a cycle ability (currently, the only one in the mod is Hammer), it will display the cycle mode it is on now.

Before, when using a T4 pickaxe with the hammer ability (supports off, 3x3, 5x5, and 7x7), the information shown in the action bar would be:
Ability: Hammer - Disabled
Ability: Hammer - Enabled
Ability: Hammer - Enabled
Ability: Hammer - Enabled

With this PR, it's now
Ability: Hammer - Disabled
Ability: Hammer: 3x3 - Enabled
Ability: Hammer: 5x5 - Enabled
Ability: Hammer: 7x7 - Enabled

Works with the other tiers of pickaxes as well.

It also uses the same translations used by the buttons.

Please note that if more cycle abilities are added, they will need to follow the same ability number/localization format that was used for the hammer ability.