### PR TITLE
Fixed time wand using incorrect client message when low on time fluid

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/common/items/TimeWand.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/items/TimeWand.java
@@ -108,7 +108,7 @@ public class TimeWand extends BasePoweredItem implements PoweredItem, FluidConta
     public boolean hasResources(Player player, ItemStack itemStack, int feCost, int fluidCost) {
         float failurePitch = 0.5F; // G# - lower pitch for failure sound
         if (!FluidContainingItem.hasEnoughFluid(itemStack, fluidCost)) {
-            player.displayClientMessage(Component.translatable("justdirethings.lowportalfluid"), true);
+            player.displayClientMessage(Component.translatable("justdirethings.lowtimefluid"), true);
             player.playNotifySound(SoundEvents.NOTE_BLOCK_IRON_XYLOPHONE.value(), SoundSource.PLAYERS, 1.0F, failurePitch);
             return false;
         }


### PR DESCRIPTION
Saw https://github.com/FTBTeam/FTB-Modpack-Issues/issues/6039 pop up, knew it would be an easy fix, so I did it