### PR TITLE
Fix: Memory Leak when placing 2 Inventory Holders

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/client/blockentityrenders/InventoryHolderBER.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/blockentityrenders/InventoryHolderBER.java
@@ -27,7 +27,7 @@ public class InventoryHolderBER extends AreaAffectingBER {
     public void render(BlockEntity blockentity, float partialTicks, PoseStack matrixStackIn, MultiBufferSource bufferIn, int combinedLightsIn, int combinedOverlayIn) {
         if (blockentity instanceof InventoryHolderBE inventoryHolderBE && inventoryHolderBE.renderPlayer) {
             // Create a fake player entity
-            if (mockPlayer == null || mockPlayer.getUUID() != inventoryHolderBE.placedByUUID)
+            if (mockPlayer == null || !mockPlayer.getUUID().equals(inventoryHolderBE.placedByUUID))
                 mockPlayer = createMockPlayer(inventoryHolderBE);
             if (mockPlayer == null) return;
             mockPlayer.yHeadRot = 0;


### PR DESCRIPTION
When you place only one inventory holder, the identity check works, but after you place a second one it starts to fail and creates a lot of objects, causing memory leaks on mods that depends on GeckoLib for example.

Edit: also, you should clear this static field on player logout or something so you don't leak this player/level when a player logout of the world and join back.