### PR TITLE
Fix external reading of xp fluid

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/common/capabilities/ExperienceHolderFluidTank.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/capabilities/ExperienceHolderFluidTank.java
@@ -26,6 +26,11 @@ public class ExperienceHolderFluidTank extends FluidTank {
         return Math.min(experienceHolderBE.exp * 20, getCapacity());
     }
 
+    @Override
+    public FluidStack getFluid() {
+        return new FluidStack(Registration.XP_FLUID_SOURCE.get(), getFluidAmount());
+    }
+
     public int getCapacity() {
         return Integer.MAX_VALUE;
     }


### PR DESCRIPTION
Fixes amount reading using mods like Applied Energistics 2 and LaserIO (the mods I tested with 😉).

Seems to sync properly on dedicated servers as well. 