### PR TITLE
fix: prevent off-hand item use when tool ability triggers

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/BaseToggleableTool.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/BaseToggleableTool.java
@@ -72,7 +72,8 @@ public abstract class BaseToggleableTool extends BasePoweredItem implements Togg
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         if (!level.isClientSide && player.isShiftKeyDown())
             openSettings(player);
-        useAbility(level, player, hand);
+        if (useAbility(level, player, hand))
+            return InteractionResultHolder.success(player.getItemInHand(hand));
         return super.use(level, player, hand);
     }
 

--- a/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/ToggleableTool.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/items/interfaces/ToggleableTool.java
@@ -425,7 +425,8 @@ public interface ToggleableTool extends ToggleableItem {
         for (Ability ability : getActiveAbilities(itemStack)) {
             if ((rightClick && LeftClickableTool.getBindingMode(itemStack, ability) == 0) || (!rightClick && leftClickAbilities.contains(ability))) {
                 if (ability.action != null) {
-                    ability.action.execute(level, player, itemStack);
+                    if (ability.action.execute(level, player, itemStack))
+                        anyRan = true;
                 }
             }
         }


### PR DESCRIPTION
### Description
This PR fixes an issue where using the Eclipsegate Wand (and other toggleable tools) would simultaneously activate any item held in the off-hand, such as a backpack or block.

The issue was caused because the tool's use method fell through to the super implementation even after an ability was successfully executed. This behavior let the interaction pass through to the off-hand.

I updated `ToggleableTool.useAbility` to return a boolean indicating if an action was taken, and modified `BaseToggleableTool.use` to consume the interaction event when an ability is used.

Fixes #483

### Testing
- Verified that using the Eclipsegate Wand's Air Burst no longer opens a backpack held in the off-hand.