### PR TITLE
Fixed JEI doesn't show recipe ids

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/client/jei/FluidDropRecipeCategory.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/FluidDropRecipeCategory.java
@@ -17,12 +17,13 @@ import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
-public class FluidDropRecipeCategory implements IRecipeCategory<FluidDropRecipe> {
-    public static final RecipeType<FluidDropRecipe> TYPE =
-            RecipeType.create(JustDireThings.MODID, "fluid_drop_recipe", FluidDropRecipe.class);
+public class FluidDropRecipeCategory implements IRecipeCategory<RecipeHolder<FluidDropRecipe>> {
+    public static final RecipeType<RecipeHolder<FluidDropRecipe>> TYPE =
+            RecipeType.createFromVanilla(Registration.FLUID_DROP_RECIPE_TYPE.get());
 
     public static final int width = 120;
     public static final int height = 40;
@@ -42,7 +43,7 @@ public class FluidDropRecipeCategory implements IRecipeCategory<FluidDropRecipe>
     }
 
     @Override
-    public RecipeType<FluidDropRecipe> getRecipeType() {
+    public RecipeType<RecipeHolder<FluidDropRecipe>> getRecipeType() {
         return TYPE;
     }
 
@@ -62,7 +63,7 @@ public class FluidDropRecipeCategory implements IRecipeCategory<FluidDropRecipe>
     }
 
     @Override
-    public void draw(FluidDropRecipe recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<FluidDropRecipe> recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
         RenderSystem.enableBlend();
         arrow.draw(gui, 34, 20);
         background.draw(gui, 17, 0);
@@ -70,17 +71,17 @@ public class FluidDropRecipeCategory implements IRecipeCategory<FluidDropRecipe>
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, FluidDropRecipe recipe, IFocusGroup focuses) {
-        BlockState input = recipe.getInput();
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<FluidDropRecipe> recipe, IFocusGroup focuses) {
+        BlockState input = recipe.value().getInput();
         IRecipeSlotBuilder inputSlotBuilder = builder.addSlot(RecipeIngredientRole.INPUT, 9, 20);
         if (input.getBlock() instanceof LiquidBlock liquidBlock) {
             inputSlotBuilder
                     .addFluidStack(liquidBlock.fluid, 1000);
         }
         builder.addSlot(RecipeIngredientRole.CATALYST, 9, 0)
-                .addItemStack(new ItemStack(recipe.getCatalyst()));
+                .addItemStack(new ItemStack(recipe.value().getCatalyst()));
 
-        BlockState output = recipe.getOutput();
+        BlockState output = recipe.value().getOutput();
         if (output.getBlock() instanceof LiquidBlock liquidBlock) {
             builder.addSlot(RecipeIngredientRole.OUTPUT, 68, 20)
                     .addFluidStack(liquidBlock.fluid, 1000);

--- a/src/main/java/com/direwolf20/justdirethings/client/jei/GooSpreadRecipeCategory.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/GooSpreadRecipeCategory.java
@@ -1,6 +1,7 @@
 package com.direwolf20.justdirethings.client.jei;
 
 import com.direwolf20.justdirethings.JustDireThings;
+import com.direwolf20.justdirethings.datagen.JustDireRecipes;
 import com.direwolf20.justdirethings.datagen.recipes.GooSpreadRecipe;
 import com.direwolf20.justdirethings.setup.Registration;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -16,17 +17,19 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class GooSpreadRecipeCategory implements IRecipeCategory<GooSpreadRecipe> {
-    public static final RecipeType<GooSpreadRecipe> TYPE =
-            RecipeType.create(JustDireThings.MODID, "goo_spread_recipe", com.direwolf20.justdirethings.datagen.recipes.GooSpreadRecipe.class);
+public class GooSpreadRecipeCategory implements IRecipeCategory<RecipeHolder<GooSpreadRecipe>> {
+    public static final RecipeType<RecipeHolder<GooSpreadRecipe>> TYPE =
+    RecipeType.createFromVanilla(Registration.GOO_SPREAD_RECIPE_TYPE.get());
 
     public static final int width = 120;
     public static final int height = 40;
@@ -46,7 +49,7 @@ public class GooSpreadRecipeCategory implements IRecipeCategory<GooSpreadRecipe>
     }
 
     @Override
-    public RecipeType<GooSpreadRecipe> getRecipeType() {
+    public RecipeType<RecipeHolder<GooSpreadRecipe>> getRecipeType() {
         return TYPE;
     }
 
@@ -66,7 +69,7 @@ public class GooSpreadRecipeCategory implements IRecipeCategory<GooSpreadRecipe>
     }
 
     @Override
-    public void draw(GooSpreadRecipe recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<GooSpreadRecipe> recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
         RenderSystem.enableBlend();
         arrow.draw(gui, 54, 12);
         background.draw(gui, 17, 0);
@@ -74,8 +77,8 @@ public class GooSpreadRecipeCategory implements IRecipeCategory<GooSpreadRecipe>
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, GooSpreadRecipe recipe, IFocusGroup focuses) {
-        BlockState input = recipe.getInput();
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<GooSpreadRecipe> recipe, IFocusGroup focuses) {
+        BlockState input = recipe.value().getInput();
         IRecipeSlotBuilder inputSlotBuilder = builder.addSlot(RecipeIngredientRole.INPUT, 9, 12);
         if (input.getBlock().asItem() != Items.AIR) {
             inputSlotBuilder
@@ -86,18 +89,18 @@ public class GooSpreadRecipeCategory implements IRecipeCategory<GooSpreadRecipe>
         }
         List<ItemStack> catalystlist = new ArrayList<>();
 
-        if (recipe.getTierRequirement() <= 1)
+        if (recipe.value().getTierRequirement() <= 1)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier1.get()));
-        if (recipe.getTierRequirement() <= 2)
+        if (recipe.value().getTierRequirement() <= 2)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier2.get()));
-        if (recipe.getTierRequirement() <= 3)
+        if (recipe.value().getTierRequirement() <= 3)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier3.get()));
-        if (recipe.getTierRequirement() <= 4)
+        if (recipe.value().getTierRequirement() <= 4)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier4.get()));
         builder.addSlot(RecipeIngredientRole.CATALYST, 29, 12)
                 .addItemStacks(catalystlist);
 
-        BlockState output = recipe.getOutput();
+        BlockState output = recipe.value().getOutput();
         if (output.getBlock().asItem() != Items.AIR) {
             builder.addSlot(RecipeIngredientRole.OUTPUT, 88, 12)
                     .addItemStack(new ItemStack(output.getBlock()));

--- a/src/main/java/com/direwolf20/justdirethings/client/jei/GooSpreadRecipeTagCategory.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/GooSpreadRecipeTagCategory.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
@@ -25,9 +26,9 @@ import net.neoforged.neoforge.common.crafting.BlockTagIngredient;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GooSpreadRecipeTagCategory implements IRecipeCategory<GooSpreadRecipeTag> {
-    public static final RecipeType<GooSpreadRecipeTag> TYPE =
-            RecipeType.create(JustDireThings.MODID, "goo_spread_recipe_tag", GooSpreadRecipeTag.class);
+public class GooSpreadRecipeTagCategory implements IRecipeCategory<RecipeHolder<GooSpreadRecipeTag>> {
+    public static final RecipeType<RecipeHolder<GooSpreadRecipeTag>> TYPE =
+            RecipeType.createFromVanilla(Registration.GOO_SPREAD_RECIPE_TYPE_TAG.get());
 
     public static final int width = 120;
     public static final int height = 40;
@@ -47,7 +48,7 @@ public class GooSpreadRecipeTagCategory implements IRecipeCategory<GooSpreadReci
     }
 
     @Override
-    public RecipeType<GooSpreadRecipeTag> getRecipeType() {
+    public RecipeType<RecipeHolder<GooSpreadRecipeTag>> getRecipeType() {
         return TYPE;
     }
 
@@ -67,7 +68,7 @@ public class GooSpreadRecipeTagCategory implements IRecipeCategory<GooSpreadReci
     }
 
     @Override
-    public void draw(GooSpreadRecipeTag recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
+    public void draw(RecipeHolder<GooSpreadRecipeTag> recipe, IRecipeSlotsView slotsView, GuiGraphics gui, double mouseX, double mouseY) {
         RenderSystem.enableBlend();
         arrow.draw(gui, 54, 12);
         background.draw(gui, 17, 0);
@@ -75,8 +76,8 @@ public class GooSpreadRecipeTagCategory implements IRecipeCategory<GooSpreadReci
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, GooSpreadRecipeTag recipe, IFocusGroup focuses) {
-        BlockTagIngredient input = recipe.getInput();
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<GooSpreadRecipeTag> recipe, IFocusGroup focuses) {
+        BlockTagIngredient input = recipe.value().getInput();
         IRecipeSlotBuilder inputSlotBuilder = builder.addSlot(RecipeIngredientRole.INPUT, 9, 12);
         List<ItemStack> itemstacks = input.getItems().toList();
         inputSlotBuilder.addItemStacks(itemstacks);
@@ -89,18 +90,18 @@ public class GooSpreadRecipeTagCategory implements IRecipeCategory<GooSpreadReci
         }*/
         List<ItemStack> catalystlist = new ArrayList<>();
 
-        if (recipe.getTierRequirement() <= 1)
+        if (recipe.value().getTierRequirement() <= 1)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier1.get()));
-        if (recipe.getTierRequirement() <= 2)
+        if (recipe.value().getTierRequirement() <= 2)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier2.get()));
-        if (recipe.getTierRequirement() <= 3)
+        if (recipe.value().getTierRequirement() <= 3)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier3.get()));
-        if (recipe.getTierRequirement() <= 4)
+        if (recipe.value().getTierRequirement() <= 4)
             catalystlist.add(new ItemStack(Registration.GooBlock_Tier4.get()));
         builder.addSlot(RecipeIngredientRole.CATALYST, 29, 12)
                 .addItemStacks(catalystlist);
 
-        BlockState output = recipe.getOutput();
+        BlockState output = recipe.value().getOutput();
         if (output.getBlock().asItem() != Items.AIR) {
             builder.addSlot(RecipeIngredientRole.OUTPUT, 88, 12)
                     .addItemStack(new ItemStack(output.getBlock()));

--- a/src/main/java/com/direwolf20/justdirethings/client/jei/JEIIntegration.java
+++ b/src/main/java/com/direwolf20/justdirethings/client/jei/JEIIntegration.java
@@ -77,18 +77,15 @@ public class JEIIntegration implements IModPlugin {
     public void registerRecipes(IRecipeRegistration registration) {
         assert Minecraft.getInstance().level != null;
         RecipeManager recipeManager = Minecraft.getInstance().level.getRecipeManager();
-        List<GooSpreadRecipe> goospreadrecipes = recipeManager.getAllRecipesFor(Registration.GOO_SPREAD_RECIPE_TYPE.get())
-                .stream().map(RecipeHolder::value).collect(Collectors.toList());
+        List<RecipeHolder<GooSpreadRecipe>> goospreadrecipes = recipeManager.getAllRecipesFor(Registration.GOO_SPREAD_RECIPE_TYPE.get());
 
         registration.addRecipes(GooSpreadRecipeCategory.TYPE, goospreadrecipes);
 
-        List<GooSpreadRecipeTag> goospreadtagrecipes = recipeManager.getAllRecipesFor(Registration.GOO_SPREAD_RECIPE_TYPE_TAG.get())
-                .stream().map(RecipeHolder::value).collect(Collectors.toList());
+        List<RecipeHolder<GooSpreadRecipeTag>> goospreadtagrecipes = recipeManager.getAllRecipesFor(Registration.GOO_SPREAD_RECIPE_TYPE_TAG.get());
 
         registration.addRecipes(GooSpreadRecipeTagCategory.TYPE, goospreadtagrecipes);
 
-        List<FluidDropRecipe> fluidDropRecipes = recipeManager.getAllRecipesFor(Registration.FLUID_DROP_RECIPE_TYPE.get())
-                .stream().map(RecipeHolder::value).collect(Collectors.toList());
+        List<RecipeHolder<FluidDropRecipe>> fluidDropRecipes = recipeManager.getAllRecipesFor(Registration.FLUID_DROP_RECIPE_TYPE.get());
 
         registration.addRecipes(FluidDropRecipeCategory.TYPE, fluidDropRecipes);
 


### PR DESCRIPTION
Changed all recipe categories `RecipeType<T>` -> `RecipeHolder<RecipeType<T>>` to allow jei to handle recipe ids from recipe holders

[OreToResourceCategory](https://github.com/DevDyna/JustDireThings-fixes/blob/jei-recipe-ids-fix/src/main/java/com/direwolf20/justdirethings/client/jei/OreToResourceCategory.java) wasn't modified due it doesn't use a proper recipetype but could be adapted overriding `IRecipeCategory.getRegistryName(T recipe) > ResourceLocation`