### PR TITLE
fix: Item sensors can't sense dropped items

### DIFF
--- a/src/main/java/com/direwolf20/justdirethings/common/blockentities/SensorT1BE.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/blockentities/SensorT1BE.java
@@ -275,6 +275,8 @@ public class SensorT1BE extends BaseMachineBE implements FilterableBE {
             return false;
         if (sense_target.equals(SENSE_TARGET.ITEM) && !(entity instanceof ItemEntity))
             return false;
+        if (sense_target.equals(SENSE_TARGET.LIVING) && !(entity instanceof Player) && !(entity instanceof Animal) && !(entity instanceof Monster))
+            return false;
         return isEntityValidFilter(entity, this.level);
     }
 

--- a/src/main/java/com/direwolf20/justdirethings/common/blockentities/basebe/FilterableBE.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/blockentities/basebe/FilterableBE.java
@@ -8,6 +8,7 @@ import com.direwolf20.justdirethings.util.interfacehelpers.FilterData;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.SpawnEggItem;
@@ -99,8 +100,13 @@ public interface FilterableBE {
                     }
                 }
             }
-
         }
+
+        if (entity instanceof ItemEntity itemEntity) {
+            getFilterData().entityCache.put(entity, isStackValidFilter(itemEntity.getItem()));
+            return getFilterData().entityCache.get(entity);
+        }
+
         getFilterData().entityCache.put(entity, !getFilterData().allowlist);
         return !getFilterData().allowlist;
     }


### PR DESCRIPTION
This fixes the following issue:
https://github.com/Direwolf20-MC/JustDireThings/issues/414

There are 2 things not working as intended: 
 - When sensors are set to detect items they check if the item in the filter is an egg or mob catcher, but don't check for anything else. This PR adds a check if the item is valid using existing methods.
 - When sensors are set to detect all living things, they detect all entities that match. Before this PR all entities that match meant living entities, but with the fix for item entities, this means the sensor should detect entities that are a player, a monster or an animal. This PR does this. 