### PR TITLE
Fix/use fake player for all BE's when calling getCloneItemStack()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 !/settings.gradle
 !/src/
 !/CHANGELOG.md
+
+# macOS kipple
+.DS_Store
+

--- a/src/main/java/com/direwolf20/justdirethings/common/blockentities/EnergyTransmitterBE.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/blockentities/EnergyTransmitterBE.java
@@ -374,7 +374,7 @@ public class EnergyTransmitterBE extends BaseMachineBE implements RedstoneContro
                     if (!foundAcceptableSide)
                         return;
 
-                    ItemStack blockItemStack = blockState.getCloneItemStack(blockPos, level, false, null);
+                    ItemStack blockItemStack = blockState.getCloneItemStack(blockPos, level, false, getUsefulFakePlayer((ServerLevel) level));
                     if (!isStackValidFilter(blockItemStack)) return;
 
                     if (blockState.getBlock() instanceof EnergyTransmitter)

--- a/src/main/java/com/direwolf20/justdirethings/common/blockentities/FluidPlacerT2BE.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/blockentities/FluidPlacerT2BE.java
@@ -93,7 +93,7 @@ public class FluidPlacerT2BE extends FluidPlacerT1BE implements PoweredMachineBE
     public boolean isBlockPosValid(BlockPos blockPos, FakePlayer fakePlayer) {
         if (!super.isBlockPosValid(blockPos, fakePlayer))
             return false; //Do the same checks as normal, then check the filters
-        ItemStack blockItemStack = level.getBlockState(blockPos.relative(getDirectionValue())).getCloneItemStack(blockPos, level, false, null);
+        ItemStack blockItemStack = level.getBlockState(blockPos.relative(getDirectionValue())).getCloneItemStack(blockPos, level, false, fakePlayer);
         return isStackValidFilter(blockItemStack);
     }
 }

--- a/src/main/java/com/direwolf20/justdirethings/common/blockentities/SensorT1BE.java
+++ b/src/main/java/com/direwolf20/justdirethings/common/blockentities/SensorT1BE.java
@@ -11,6 +11,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
@@ -326,7 +327,7 @@ public class SensorT1BE extends BaseMachineBE implements FilterableBE {
     }
 
     public boolean handleBlockStates(BlockPos blockPos, BlockState blockState) {
-        ItemStack blockItemStack = blockState.getCloneItemStack(blockPos, level, false, null);
+        ItemStack blockItemStack = blockState.getCloneItemStack(blockPos, level, false, getUsefulFakePlayer((ServerLevel) level));
         boolean allowList = filterData.allowlist;
         if (blockStateFilterCache.containsKey(blockState))
             return blockStateFilterCache.get(blockState);


### PR DESCRIPTION
To start, it's just fixing the EnergyTransmitter so it does not crash when Ender IO energy conduits are in range.

Plan is to apply same change (passing usefulFakePlayer) to all calls to getCloneItemStack() in all BE's.

Cheers.